### PR TITLE
group private endpoints use api key header auth

### DIFF
--- a/handlers/handler.go
+++ b/handlers/handler.go
@@ -42,6 +42,10 @@ func NewRecipesHandler(ctx context.Context, collection *mongo.Collection, redisC
 //         description: Invalid input
 func (handler *RecipesHandler) NewRecipeHandler(c *gin.Context) {
 	var recipe models.Recipe
+	if c.GetHeader("X-API-KEY") != myAPIKey {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "API key not provided or invalid"})
+		return
+	}
 	if err := c.ShouldBindJSON(&recipe); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return

--- a/handlers/middleware.go
+++ b/handlers/middleware.go
@@ -1,0 +1,17 @@
+package handlers
+
+import (
+	"github.com/gin-gonic/gin"
+)
+
+const myAPIKey = "eUbP9shywUygMx7u"
+
+//AuthMiddleware use http header api key to verify the request for authorization
+func AuthMiddleware() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if c.GetHeader("X-API-KEY") != myAPIKey {
+			c.AbortWithStatus(401)
+		}
+		c.Next()
+	}
+}

--- a/main.go
+++ b/main.go
@@ -60,12 +60,19 @@ func init() {
 }
 
 func main() {
+	// for public  api endpoints
 	router := gin.Default()
-	router.POST("/recipes", recipesHandler.NewRecipeHandler)
 	router.GET("/recipes", recipesHandler.ListRecipesHandler)
-	router.PUT("/recipes/:id", recipesHandler.UpdateRecipeHandler)
-	router.DELETE("/recipes/:id", recipesHandler.DeleteRecipeHandler)
-	router.GET("/recipes/:id", recipesHandler.GetOneRecipeHandler)
-	//router.GET("/recipes/search", SearchRecipesHandler)
+
+	// for private api endpoints
+	authorized := router.Group("/")
+	authorized.Use(handlers.AuthMiddleware())
+	{
+		authorized.POST("/recipes", recipesHandler.NewRecipeHandler)
+		authorized.PUT("/recipes/:id", recipesHandler.UpdateRecipeHandler)
+		authorized.DELETE("/recipes/:id", recipesHandler.DeleteRecipeHandler)
+		authorized.GET("/recipes/:id", recipesHandler.GetOneRecipeHandler)
+	}
+
 	router.Run()
 }


### PR DESCRIPTION
API keys are a simple way to auth HTTP requests
* Disadvantages: the key can be picked up easily with a **man-in-the-middle** attack
when no encryption is in use.
