### PR TITLE
scale the recipes API by serving it behind a reverse proxy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM golang:1.17
+WORKDIR /go/src/github.com/api
+COPY . .
+RUN go mod download
+RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o app .
+
+FROM alpine:latest
+RUN apk --no-cache add ca-certificates
+WORKDIR /root/
+COPY --from=0 /go/src/github.com/api/app .
+CMD ["./app"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,45 @@
+version: "3.9"
+
+services:
+  api:
+    image: recipes-api
+    environment:
+      - MONGO_URI=mongodb://admin:password@mongodb:27017/recipes-store?authSource=admin&readPreference=primary&ssl=false
+      - MONGO_DATABASE=recipes-store
+      - REDIS_URI=redis:6379
+    networks:
+      - api_network
+    external_links:
+      - mongodb
+      - redis
+    scale: 5
+  redis:
+    image: redis
+    networks:
+      - api_network
+    ports:
+      - 6379:6379
+
+  mongodb:
+    image: mongo:4.4.3
+    networks:
+      - api_network
+    ports:
+      - 27017:27017
+    environment:
+      - MONGO_INITDB_ROOT_USERNAME=admin
+      - MONGO_INITDB_ROOT_PASSWORD=password
+
+  nginx:
+    image: nginx
+    ports:
+      - 80:80
+    volumes:
+      - $PWD/nginx.conf:/etc/nginx/nginx.conf
+    depends_on:
+      - api
+    networks:
+      - api_network
+
+networks:
+  api_network:

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,18 @@
+events {
+    worker_connections 1024;
+}
+
+
+http {
+  server_tokens off;
+  server {
+    listen 80;
+    root /var/www;
+
+    location /api/ {
+      proxy_set_header X-Forwarded-For $remote_addr;
+      proxy_set_header Host            $http_host;
+      proxy_pass http://api:8080/;
+    }
+  }
+}


### PR DESCRIPTION
Use Nginx as a reverse proxy
- nginx faces the client and receives the incoming HTTP(s) requests, then redirects them to one of the API instances
- use docker-compose to orchestrate the containers
     - API: The Recipes API container
     - Redis: The in-memory caching database
     - MongoDB: The NoSQL database where the recipes stored
     - scale API up to 5 instances
